### PR TITLE
feat(transaction): 가계부 카테고리

### DIFF
--- a/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/command/application/service/TransactionService.java
+++ b/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/command/application/service/TransactionService.java
@@ -2,6 +2,7 @@ package com.aespa.armageddon.core.domain.transaction.command.application.service
 
 import com.aespa.armageddon.core.domain.transaction.command.application.dto.request.TransactionWriteRequest;
 import com.aespa.armageddon.core.domain.transaction.command.domain.aggregate.Transaction;
+import com.aespa.armageddon.core.domain.transaction.command.domain.aggregate.TransactionType;
 import com.aespa.armageddon.core.domain.transaction.command.domain.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -50,11 +51,15 @@ public class TransactionService {
         }
 
         if (request.type() == null) {
-            throw new IllegalArgumentException("거래 타입은 필수입니다.");
+            throw new IllegalArgumentException("지출/수입 타입은 필수입니다.");
         }
 
-        if (request.category() == null) {
-            throw new IllegalArgumentException("카테고리는 필수입니다.");
+        if (request.type() == TransactionType.EXPENSE && request.category() == null) {
+            throw new IllegalArgumentException("지출일 경우 카테고리는 필수입니다.");
+        }
+
+        if (request.type() == TransactionType.INCOME && request.category() != null) {
+            throw new IllegalArgumentException("수입에는 카테고리를 입력할 수 없습니다.");
         }
     }
 }

--- a/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/command/domain/aggregate/Transaction.java
+++ b/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/command/domain/aggregate/Transaction.java
@@ -38,7 +38,6 @@ public class Transaction {
     private TransactionType type;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private Category category;
 
     public Transaction(


### PR DESCRIPTION
## 변경 사항
- 카테고리가 지출 일때 만 입력 되게 햇어야 햇는데 그러지 못함 >> 이 문제를 해결함
## 작업 내용
- [x] 기능 구현
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 디자인 요소 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)

## 체크리스트
- [x] 중요!! : run했을 때 멈추지 않고 돌아가는가
- [x] Push 전 pull dev 했는가
- [x] 불필요한 코드/주석이 없는가

## 참고 사항
 
- 수입(카테고리가 있을 경우)
<img width="830" height="550" alt="image" src="https://github.com/user-attachments/assets/afc04516-c5fc-494d-8f77-fc290dee232a" />

 - 지출(카테고리가 없을 경우)
<img width="836" height="594" alt="image" src="https://github.com/user-attachments/assets/420afcea-112b-4e1d-9dd9-e8abb72b98af" />

 - 지출(카테고리가 있을 경우)
<img width="849" height="621" alt="image" src="https://github.com/user-attachments/assets/f94a109d-5968-4d1a-8a4a-89bfd9c7b5b5" />

