### PR TITLE
feat(transation): transactionSummary query update

### DIFF
--- a/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/query/dto/TransactionSummaryResponse.java
+++ b/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/query/dto/TransactionSummaryResponse.java
@@ -1,0 +1,20 @@
+package com.aespa.armageddon.core.domain.transaction.query.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+@Data
+public class TransactionSummaryResponse {
+
+    private Long totalIncome;       // 총 수입
+    private Long totalExpense;      // 총 지출
+    private Long balance;           // 잔액 (총 수입 - 총 지출)
+
+    @QueryProjection
+    public TransactionSummaryResponse(Long totalIncome, Long totalExpense) {
+        // null값이 넘어올 경우 0으로 처리
+        this.totalIncome = totalIncome != null ? totalIncome : 0L;
+        this.totalExpense = totalExpense != null ? totalExpense : 0L;
+        this.balance = this.totalIncome - this.totalExpense;
+    }
+}

--- a/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/query/repository/TransactionQueryRepository.java
+++ b/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/query/repository/TransactionQueryRepository.java
@@ -1,7 +1,11 @@
 package com.aespa.armageddon.core.domain.transaction.query.repository;
 
+import com.aespa.armageddon.core.domain.transaction.command.domain.aggregate.TransactionType;
 import com.aespa.armageddon.core.domain.transaction.query.dto.QTransactionResponse;
+import com.aespa.armageddon.core.domain.transaction.query.dto.QTransactionSummaryResponse;
 import com.aespa.armageddon.core.domain.transaction.query.dto.TransactionResponse;
+import com.aespa.armageddon.core.domain.transaction.query.dto.TransactionSummaryResponse;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -31,5 +35,36 @@ public class TransactionQueryRepository {
                         transaction.date.eq(date)           // 요청한 날짜의 내역 조회
                 )
                 .fetch();
+    }
+
+    /* 월간 총 수입/지출/잔액 요약 조회 */
+    public TransactionSummaryResponse findMonthlySummary(Long userNo, int year, int month) {
+
+        // 검색할 월의 시작일과 마지막일 계산
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        return queryFactory
+                .select(new QTransactionSummaryResponse(
+                        // 1. 수입 합계
+                        new CaseBuilder()
+                                .when(transaction.type.eq(TransactionType.INCOME))
+                                .then(transaction.amount.longValue()) // int -> long 타입변환
+                                .otherwise(0L)               // 조건 맞지 않으면 0
+                                .sum(),                              // 합계
+
+                        // 2. 지출 합계
+                        new CaseBuilder()
+                                .when(transaction.type.eq(TransactionType.EXPENSE))
+                                .then(transaction.amount.longValue())
+                                .otherwise(0L)
+                                .sum()
+                ))
+                .from(transaction)
+                .where(
+                        transaction.userNo.eq(userNo),
+                        transaction.date.between(startDate, endDate)    // 해당 월 데이터만
+                )
+                .fetchOne();
     }
 }

--- a/backend/armageddon/src/test/java/com/aespa/armageddon/core/domain/transaction/query/repository/TransactionQueryRepositoryTest.java
+++ b/backend/armageddon/src/test/java/com/aespa/armageddon/core/domain/transaction/query/repository/TransactionQueryRepositoryTest.java
@@ -5,6 +5,7 @@ import com.aespa.armageddon.core.domain.transaction.command.domain.aggregate.Cat
 import com.aespa.armageddon.core.domain.transaction.command.domain.aggregate.Transaction;
 import com.aespa.armageddon.core.domain.transaction.command.domain.aggregate.TransactionType;
 import com.aespa.armageddon.core.domain.transaction.query.dto.TransactionResponse;
+import com.aespa.armageddon.core.domain.transaction.query.dto.TransactionSummaryResponse;
 import com.aespa.armageddon.core.global.config.QueryDslConfig;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
@@ -36,9 +37,9 @@ class TransactionQueryRepositoryTest {
         Long userNo = 1L;
         LocalDate today = LocalDate.of(2026, 1 , 9);
 
-        Transaction t1 = createTransaction(userNo, today, "스타벅스", 6500, TransactionType.EXPENSE);
-        Transaction t2 = createTransaction(userNo, today.minusDays(1), "편의점", 3000, TransactionType.EXPENSE);
-        Transaction t3 = createTransaction(2L, today, "월급", 5000000, TransactionType.INCOME);
+        Transaction t1 = createTransaction(userNo, today, "스타벅스", 6500, TransactionType.EXPENSE, Category.FOOD);
+        Transaction t2 = createTransaction(userNo, today.minusDays(1), "편의점", 3000, TransactionType.EXPENSE, Category.FOOD);
+        Transaction t3 = createTransaction(2L, today, "월급", 5000000, TransactionType.INCOME, null);
 
         em.persist(t1);
         em.persist(t2);
@@ -62,7 +63,7 @@ class TransactionQueryRepositoryTest {
 
     }
 
-    private Transaction createTransaction(Long userNo, LocalDate date, String title, int amount, TransactionType type) {
+    private Transaction createTransaction(Long userNo, LocalDate date, String title, int amount, TransactionType type, Category category) {
 
         return new Transaction(
                 userNo,
@@ -71,8 +72,57 @@ class TransactionQueryRepositoryTest {
                 amount,
                 date,
                 type,
-                Category.FOOD
+                category
         );
 
+    }
+
+    @Test
+    @DisplayName("월간 수입/지출/잔액 요약이 정확히 계산되어야 한다")
+    void findMonthlySummaryTest() {
+        // given (준비)
+        Long userNo = 1L;
+        int year = 2024;
+        int month = 5; // 5월 데이터를 조회한다고 가정
+
+        // 1. [포함 O] 5월 수입 (100,000원)
+        Transaction t1 = createTransaction(userNo, LocalDate.of(year, month, 1),"월급", 100000, TransactionType.INCOME, null);
+
+        // 2. [포함 O] 5월 지출 (30,000원)
+        Transaction t2 = createTransaction(userNo, LocalDate.of(year, month, 15), "쇼핑", 30000, TransactionType.EXPENSE, Category.SHOPPING);
+
+        // 3. [포함 O] 5월 지출 (10,000원) - 지출이 여러 건일 때 합산 잘 되는지
+        Transaction t3 = createTransaction(userNo, LocalDate.of(year, month, 31), "식비", 10000, TransactionType.EXPENSE, Category.FOOD);
+
+        // 4. [포함 X] 4월 데이터 (날짜 범위 밖)
+        Transaction t4 = createTransaction(userNo, LocalDate.of(year, 4, 30), "지난달", 50000, TransactionType.INCOME, null);
+
+        // 5. [포함 X] 다른 유저 데이터
+        Transaction t5 = createTransaction(2L, LocalDate.of(year, month, 10), "남의돈", 999999, TransactionType.INCOME, null);
+
+        em.persist(t1);
+        em.persist(t2);
+        em.persist(t3);
+        em.persist(t4);
+        em.persist(t5);
+
+        // 영속성 컨텍스트 비우기 (DB에서 쿼리로 진짜 계산해오는지 확인 위함)
+        em.flush();
+        em.clear();
+
+        // when (실행)
+        TransactionSummaryResponse result = transactionQueryRepository.findMonthlySummary(userNo, year, month);
+
+        // then (검증)
+        // 예상 수입: 100,000 (t1)
+        assertThat(result.getTotalIncome()).isEqualTo(100000L);
+
+        // 예상 지출: 30,000 (t2) + 10,000 (t3) = 40,000
+        assertThat(result.getTotalExpense()).isEqualTo(40000L);
+
+        // 예상 잔액: 100,000 - 40,000 = 60,000
+        assertThat(result.getBalance()).isEqualTo(60000L);
+
+        System.out.println("테스트 성공 결과: " + result);
     }
 }


### PR DESCRIPTION
## 변경 사항
- 사용자가 특정 월의 총 수입/ 총 지출 / 잔액 ( 총 수입 - 총 지출) 값 확인 할수 있도록 

## 작업 내용
- [x] 기능 구현
- [ ] 리팩토링
- [ ] 버그 수정
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 디자인 요소 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)

## 체크리스트
- [x] 중요!! : run했을 때 멈추지 않고 돌아가는가
- [x] Push 전 pull dev 했는가
- [x] 불필요한 코드/주석이 없는가

## 참고 사항(생략 가능)
- 리뷰어가 알면 좋은 내용 (스크린샷, 로그, 설계 설명 등)

<img width="1543" height="855" alt="카테고리 입력 오류" src="https://github.com/user-attachments/assets/f2d4f675-6752-43f8-9a3b-b3df68300fa0" />
- 수입일 경우 카테고리가 입력 되었을시 오류 발생


<img width="1585" height="880" alt="카테고리 수입 해결" src="https://github.com/user-attachments/assets/c3933d46-7b26-4ee5-b8d5-ee4e46c0e09a" />
- 수입 카테고리 null 입력시 테스트 통과