### PR TITLE
refactor(user): CustomUserDetails로 전환 및 타 기능 컨트롤러 수정

### DIFF
--- a/backend/armageddon/docs/TEST_SPECIFICATION.md
+++ b/backend/armageddon/docs/TEST_SPECIFICATION.md
@@ -1,0 +1,268 @@
+# User/Auth 테스트 명세서
+
+## 개요
+
+| 항목 | 내용 |
+|------|------|
+| 테스트 대상 | User/Auth 기능 |
+| 테스트 프레임워크 | JUnit 5, Mockito, MockMvc |
+| 총 테스트 수 | 97개 |
+| 테스트 레이어 | Service, Controller |
+
+---
+
+## 1. Service Layer 테스트
+
+### 1.1 UserService 테스트
+
+#### 회원가입 (signup)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 회원가입 성공 | 사용자 ID 반환 | - |
+| 중복된 로그인 아이디 | CoreException | U003 |
+| 중복된 이메일 | CoreException | U002 |
+| 이메일 인증 미완료 | CoreException | A006 |
+
+#### 프로필 수정 (updateProfile)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 닉네임 변경 성공 | 수정된 User 반환 | - |
+| 로그인 아이디 변경 성공 | 수정된 User 반환, 토큰 삭제 | - |
+| 이메일 변경 성공 | 수정된 User 반환 | - |
+| 현재 로그인 아이디가 null | CoreException | C002 |
+| 사용자를 찾을 수 없음 | CoreException | U001 |
+| 변경할 항목 없음 | CoreException | C002 |
+| 잘못된 비밀번호 | CoreException | U004 |
+| 비밀번호가 null | CoreException | U004 |
+| 중복된 로그인 아이디 | CoreException | U003 |
+| 중복된 이메일 | CoreException | U002 |
+| 이메일 인증 미완료 | CoreException | A006 |
+
+#### 계정 삭제 (deleteAccount)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 계정 삭제 성공 | 정상 완료 | - |
+| 현재 로그인 아이디가 null | CoreException | C002 |
+| 사용자를 찾을 수 없음 | CoreException | U001 |
+
+#### 프로필 조회 (getProfile)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 프로필 조회 성공 | User 반환 | - |
+| 현재 로그인 아이디가 null | CoreException | C002 |
+| 사용자를 찾을 수 없음 | CoreException | U001 |
+
+---
+
+### 1.2 AuthService 테스트
+
+#### 로그인 (login)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 로그인 성공 | TokenResponse 반환 | - |
+| 사용자를 찾을 수 없음 | CoreException | A003 |
+| 비밀번호 불일치 | CoreException | A003 |
+
+#### 토큰 갱신 (refreshToken)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 토큰 갱신 성공 | TokenResponse 반환 | - |
+| 유효하지 않은 토큰 | CoreException | A001 |
+| 만료된 토큰 | CoreException | A004 |
+| 저장된 토큰과 불일치 | CoreException | A001 |
+| 저장된 토큰이 없음 | CoreException | A001 |
+| 사용자를 찾을 수 없음 | CoreException | U001 |
+
+#### 로그아웃 (logout)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 로그아웃 성공 | 정상 완료 | - |
+| 유효하지 않은 토큰 | CoreException | A001 |
+| 만료된 토큰 | CoreException | A004 |
+
+---
+
+### 1.3 EmailVerificationService 테스트
+
+#### 이메일 인증 요청 (requestVerification)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 인증 요청 성공 | 6자리 코드 발송 | - |
+| 이메일이 null | CoreException | C002 |
+| 이메일이 빈 문자열 | CoreException | C002 |
+
+#### 이메일 인증 확인 (confirmVerification)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 인증 확인 성공 | 인증 완료 처리 | - |
+| 이메일이 null | CoreException | C002 |
+| 코드가 null | CoreException | C002 |
+| 코드가 빈 문자열 | CoreException | C002 |
+| 저장된 코드가 없음 | CoreException | A007 |
+| 코드 불일치 | CoreException | A007 |
+
+#### 인증 확인 및 소비 (assertVerifiedAndConsume)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 확인 및 소비 성공 | 인증 정보 삭제 | - |
+| 이메일이 null | CoreException | C002 |
+| 이메일 인증 미완료 | CoreException | A006 |
+
+#### 이메일 인증 정보 삭제 (deleteByEmail)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 삭제 성공 | 정상 완료 | - |
+| 이메일이 null | 무시 | - |
+| 빈 문자열 | 무시 | - |
+
+---
+
+### 1.4 PasswordResetService 테스트
+
+#### 비밀번호 재설정 요청 (requestReset)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 재설정 요청 성공 | 6자리 코드 발송 | - |
+| 요청이 null | CoreException | C002 |
+| loginId가 null | CoreException | C002 |
+| email이 null | CoreException | C002 |
+| 사용자를 찾을 수 없음 | CoreException | U001 |
+| 이메일 불일치 | CoreException | C002 |
+
+#### 비밀번호 재설정 확인 (confirmReset)
+| 테스트 케이스 | 예상 결과 | ErrorCode |
+|--------------|----------|-----------|
+| 재설정 확인 성공 | 비밀번호 변경 | - |
+| 요청이 null | CoreException | C002 |
+| loginId가 null | CoreException | C002 |
+| code가 null | CoreException | C002 |
+| newPassword가 null | CoreException | C002 |
+| 사용자를 찾을 수 없음 | CoreException | A005 |
+| 저장된 코드가 없음 | CoreException | A005 |
+| 코드 불일치 | CoreException | A005 |
+| 기존 비밀번호와 동일 | CoreException | A008 |
+
+---
+
+## 2. Controller Layer 테스트
+
+### 2.1 AuthController 테스트
+
+#### POST /api/auth/signup
+| 테스트 케이스 | HTTP Status | ErrorCode |
+|--------------|-------------|-----------|
+| 회원가입 성공 | 200 OK | - |
+| 중복된 로그인 아이디 | 409 Conflict | U003 |
+| 중복된 이메일 | 409 Conflict | U002 |
+| 이메일 인증 미완료 | 400 Bad Request | A006 |
+| 유효성 검증 실패 (짧은 loginId) | 400 Bad Request | C002 |
+| 유효성 검증 실패 (잘못된 이메일) | 400 Bad Request | C002 |
+| 유효성 검증 실패 (짧은 비밀번호) | 400 Bad Request | C002 |
+
+#### POST /api/auth/login
+| 테스트 케이스 | HTTP Status | ErrorCode |
+|--------------|-------------|-----------|
+| 로그인 성공 | 200 OK | - |
+| 잘못된 자격 증명 | 401 Unauthorized | A003 |
+| 유효성 검증 실패 (빈 loginId) | 400 Bad Request | C002 |
+
+#### POST /api/auth/refresh
+| 테스트 케이스 | HTTP Status | ErrorCode |
+|--------------|-------------|-----------|
+| 토큰 갱신 성공 | 200 OK | - |
+| 인증되지 않음 | 401 Unauthorized | A001 |
+| 세션 만료 | 401 Unauthorized | A004 |
+| 사용자를 찾을 수 없음 | 404 Not Found | U001 |
+| 유효성 검증 실패 (빈 refreshToken) | 400 Bad Request | C002 |
+
+#### POST /api/auth/logout
+| 테스트 케이스 | HTTP Status | ErrorCode |
+|--------------|-------------|-----------|
+| 로그아웃 성공 | 200 OK | - |
+| 인증되지 않음 | 401 Unauthorized | A001 |
+| 세션 만료 | 401 Unauthorized | A004 |
+
+---
+
+### 2.2 UserController 테스트
+
+#### GET /api/users/me
+| 테스트 케이스 | HTTP Status | ErrorCode |
+|--------------|-------------|-----------|
+| 프로필 조회 성공 | 200 OK | - |
+| 사용자를 찾을 수 없음 | 404 Not Found | U001 |
+| 잘못된 입력값 | 400 Bad Request | C002 |
+
+#### PUT /api/users/update
+| 테스트 케이스 | HTTP Status | ErrorCode |
+|--------------|-------------|-----------|
+| 닉네임 변경 성공 | 200 OK | - |
+| 로그인 아이디 변경 성공 | 200 OK | - |
+| 사용자를 찾을 수 없음 | 404 Not Found | U001 |
+| 잘못된 비밀번호 | 400 Bad Request | U004 |
+| 중복된 로그인 아이디 | 409 Conflict | U003 |
+| 중복된 이메일 | 409 Conflict | U002 |
+| 이메일 인증 미완료 | 400 Bad Request | A006 |
+| 잘못된 입력값 | 400 Bad Request | C002 |
+| 유효성 검증 실패 (짧은 loginId) | 400 Bad Request | C002 |
+| 유효성 검증 실패 (빈 currentPassword) | 400 Bad Request | C002 |
+
+#### DELETE /api/users/delete
+| 테스트 케이스 | HTTP Status | ErrorCode |
+|--------------|-------------|-----------|
+| 계정 삭제 성공 | 200 OK | - |
+| 사용자를 찾을 수 없음 | 404 Not Found | U001 |
+| 잘못된 입력값 | 400 Bad Request | C002 |
+
+---
+
+## 3. ErrorCode 목록
+
+| ErrorCode | HTTP Status | 메시지 |
+|-----------|-------------|--------|
+| C002 | 400 | 잘못된 입력값입니다. |
+| U001 | 404 | 사용자를 찾을 수 없습니다. |
+| U002 | 409 | 이미 사용 중인 이메일입니다. |
+| U003 | 409 | 이미 사용 중인 아이디입니다. |
+| U004 | 400 | 비밀번호가 올바르지 않습니다. |
+| A001 | 401 | 인증이 필요합니다. |
+| A003 | 401 | 아이디 또는 비밀번호가 올바르지 않습니다. |
+| A004 | 401 | 세션이 만료되었습니다. |
+| A005 | 400 | 비밀번호 재설정 코드가 유효하지 않거나 만료되었습니다. |
+| A006 | 400 | 이메일 인증이 필요합니다. |
+| A007 | 400 | 이메일 인증 코드가 유효하지 않거나 만료되었습니다. |
+| A008 | 400 | 기존 비밀번호와 동일한 비밀번호로는 변경할 수 없습니다. |
+
+---
+
+## 4. 테스트 실행 방법
+
+```bash
+# 전체 테스트 실행
+./gradlew test
+
+# User/Auth 관련 테스트만 실행
+./gradlew test --tests "com.aespa.armageddon.core.domain.auth.service.*" \
+               --tests "com.aespa.armageddon.core.api.auth.controller.*" \
+               --tests "com.aespa.armageddon.core.api.user.controller.*"
+```
+
+---
+
+## 5. 테스트 파일 위치
+
+```
+src/test/java/com/aespa/armageddon/
+├── core/
+│   ├── api/
+│   │   ├── auth/controller/
+│   │   │   └── AuthControllerTest.java
+│   │   └── user/controller/
+│   │       ├── UserControllerTest.java
+│   │       └── MockUserDetailsArgumentResolver.java
+│   └── domain/auth/service/
+│       ├── UserServiceTest.java
+│       ├── AuthServiceTest.java
+│       ├── EmailVerificationServiceTest.java
+│       └── PasswordResetServiceTest.java
+```

--- a/backend/armageddon/src/main/java/com/aespa/armageddon/core/api/user/controller/UserController.java
+++ b/backend/armageddon/src/main/java/com/aespa/armageddon/core/api/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.aespa.armageddon.core.api.user.dto.response.UserProfileResponse;
 import com.aespa.armageddon.core.api.user.dto.response.UserResponse;
 import com.aespa.armageddon.core.common.support.response.ApiResult;
 import com.aespa.armageddon.core.domain.auth.entity.User;
+import com.aespa.armageddon.core.domain.auth.security.CustomUserDetails;
 import com.aespa.armageddon.core.domain.auth.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -12,7 +13,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -31,14 +31,14 @@ public class UserController {
 
     @GetMapping("/me")
     @Operation(summary = "Get current user profile")
-    public ApiResult<UserProfileResponse> getProfile(@AuthenticationPrincipal UserDetails userDetails) {
+    public ApiResult<UserProfileResponse> getProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
         User user = userService.getProfile(userDetails.getUsername());
         return ApiResult.success(UserProfileResponse.from(user));
     }
 
     @PutMapping("/update")
     @Operation(summary = "Update current user profile")
-    public ApiResult<UserResponse> updateUser(@AuthenticationPrincipal UserDetails userDetails,
+    public ApiResult<UserResponse> updateUser(@AuthenticationPrincipal CustomUserDetails userDetails,
                                             @Valid @RequestBody UserUpdateRequest request) {
         User updated = userService.updateProfile(
                 userDetails.getUsername(),
@@ -52,7 +52,7 @@ public class UserController {
 
     @DeleteMapping("/delete")
     @Operation(summary = "Delete current user")
-    public ApiResult<?> deleteUser(@AuthenticationPrincipal UserDetails userDetails) {
+    public ApiResult<?> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.deleteAccount(userDetails.getUsername());
         return ApiResult.success();
     }

--- a/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/auth/security/CustomUserDetails.java
+++ b/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/auth/security/CustomUserDetails.java
@@ -1,0 +1,72 @@
+package com.aespa.armageddon.core.domain.auth.security;
+
+import com.aespa.armageddon.core.domain.auth.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Long userId;
+    private final String loginId;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(Long userId, String loginId, String password,
+                             Collection<? extends GrantedAuthority> authorities) {
+        this.userId = userId;
+        this.loginId = loginId;
+        this.password = password;
+        this.authorities = authorities == null ? Collections.emptyList() : authorities;
+    }
+
+    public static CustomUserDetails from(User user) {
+        return new CustomUserDetails(
+                user.getId(),
+                user.getLoginId(),
+                user.getPassword(),
+                Collections.emptyList()
+        );
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return loginId;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/auth/service/CustomUserDetailsService.java
+++ b/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/auth/service/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package com.aespa.armageddon.core.domain.auth.service;
 
 import com.aespa.armageddon.core.domain.auth.entity.User;
+import com.aespa.armageddon.core.domain.auth.security.CustomUserDetails;
 import com.aespa.armageddon.core.domain.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -8,7 +9,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
@@ -21,10 +21,6 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found: " + loginId));
 
-        return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getLoginId())
-                .password(user.getPassword())
-                .authorities(Collections.emptyList())
-                .build();
+        return CustomUserDetails.from(user);
     }
 }

--- a/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/goal/controller/GoalController.java
+++ b/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/goal/controller/GoalController.java
@@ -1,18 +1,18 @@
 package com.aespa.armageddon.core.domain.goal.controller;
 
 import com.aespa.armageddon.core.common.support.response.ApiResult;
+import com.aespa.armageddon.core.domain.auth.security.CustomUserDetails;
 import com.aespa.armageddon.core.domain.goal.dto.request.CreateExpenseGoalRequest;
 import com.aespa.armageddon.core.domain.goal.dto.request.CreateSavingGoalRequest;
 import com.aespa.armageddon.core.domain.goal.dto.request.UpdateGoalRequest;
 import com.aespa.armageddon.core.domain.goal.dto.response.GoalDetailResponse;
 import com.aespa.armageddon.core.domain.goal.dto.response.GoalResponse;
 import com.aespa.armageddon.core.domain.goal.service.GoalService;
-import com.aespa.armageddon.infra.security.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,12 +25,6 @@ import java.util.List;
 public class GoalController {
 
         private final GoalService goalService;
-        private final JwtTokenProvider jwtTokenProvider;
-
-        private Long extractUserId(String authorization) {
-                String token = authorization.substring(7); // "Bearer "
-                return jwtTokenProvider.getUserIdFromJWT(token);
-        }
 
         /**
          * 목표 전체 조회 (저축 + 지출)
@@ -38,11 +32,9 @@ public class GoalController {
         @GetMapping
         @Operation(summary = "Get all goals")
         public ApiResult<List<GoalResponse>> getGoals(
-                        @Parameter(description = "Bearer access token", required = true, example = "Bearer eyJ...")
-                        @RequestHeader("Authorization") String authorization) {
+                        @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-                Long userId = extractUserId(authorization);
-                return ApiResult.success(goalService.getGoals(userId));
+                return ApiResult.success(goalService.getGoals(userDetails.getUserId()));
         }
 
         /**
@@ -51,13 +43,10 @@ public class GoalController {
         @GetMapping("/{goalId}")
         @Operation(summary = "Get goal details")
         public ApiResult<GoalDetailResponse> getGoalDetail(
-                        @Parameter(description = "Bearer access token", required = true, example = "Bearer eyJ...")
-                        @RequestHeader("Authorization") String authorization,
-                        @Parameter(description = "Goal id")
+                        @AuthenticationPrincipal CustomUserDetails userDetails,
                         @PathVariable Long goalId) {
 
-                Long userId = extractUserId(authorization);
-                return ApiResult.success(goalService.getGoalDetail(userId, goalId));
+                return ApiResult.success(goalService.getGoalDetail(userDetails.getUserId(), goalId));
         }
 
         /**
@@ -66,12 +55,10 @@ public class GoalController {
         @PostMapping("/saving")
         @Operation(summary = "Create saving goal")
         public ApiResult<?> createSavingGoal(
-                        @Parameter(description = "Bearer access token", required = true, example = "Bearer eyJ...")
-                        @RequestHeader("Authorization") String authorization,
+                        @AuthenticationPrincipal CustomUserDetails userDetails,
                         @RequestBody CreateSavingGoalRequest request) {
 
-                Long userId = extractUserId(authorization);
-                goalService.createSavingGoal(userId, request);
+                goalService.createSavingGoal(userDetails.getUserId(), request);
                 return ApiResult.success();
         }
 
@@ -81,12 +68,10 @@ public class GoalController {
         @PostMapping("/expense")
         @Operation(summary = "Create expense goal")
         public ApiResult<?> createExpenseGoal(
-                        @Parameter(description = "Bearer access token", required = true, example = "Bearer eyJ...")
-                        @RequestHeader("Authorization") String authorization,
+                        @AuthenticationPrincipal CustomUserDetails userDetails,
                         @RequestBody CreateExpenseGoalRequest request) {
 
-                Long userId = extractUserId(authorization);
-                goalService.createExpenseGoal(userId, request);
+                goalService.createExpenseGoal(userDetails.getUserId(), request);
                 return ApiResult.success();
         }
 
@@ -96,14 +81,11 @@ public class GoalController {
         @PutMapping("/{goalId}")
         @Operation(summary = "Update goal")
         public ApiResult<?> updateGoal(
-                        @Parameter(description = "Bearer access token", required = true, example = "Bearer eyJ...")
-                        @RequestHeader("Authorization") String authorization,
-                        @Parameter(description = "Goal id")
+                        @AuthenticationPrincipal CustomUserDetails userDetails,
                         @PathVariable Long goalId,
                         @RequestBody UpdateGoalRequest request) {
 
-                Long userId = extractUserId(authorization);
-                goalService.updateGoal(userId, goalId, request);
+                goalService.updateGoal(userDetails.getUserId(), goalId, request);
                 return ApiResult.success();
         }
 
@@ -113,13 +95,10 @@ public class GoalController {
         @DeleteMapping("/{goalId}")
         @Operation(summary = "Delete goal")
         public ApiResult<?> deleteGoal(
-                        @Parameter(description = "Bearer access token", required = true, example = "Bearer eyJ...")
-                        @RequestHeader("Authorization") String authorization,
-                        @Parameter(description = "Goal id")
+                        @AuthenticationPrincipal CustomUserDetails userDetails,
                         @PathVariable Long goalId) {
 
-                Long userId = extractUserId(authorization);
-                goalService.deleteGoal(userId, goalId);
+                goalService.deleteGoal(userDetails.getUserId(), goalId);
                 return ApiResult.success();
         }
 }

--- a/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/command/application/controller/TransactionController.java
+++ b/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/command/application/controller/TransactionController.java
@@ -1,16 +1,15 @@
 package com.aespa.armageddon.core.domain.transaction.command.application.controller;
 
 import com.aespa.armageddon.core.common.support.response.ApiResult;
-import com.aespa.armageddon.core.domain.auth.entity.User;
+import com.aespa.armageddon.core.domain.auth.security.CustomUserDetails;
 import com.aespa.armageddon.core.domain.transaction.command.application.dto.request.TransactionEditRequest;
 import com.aespa.armageddon.core.domain.transaction.command.application.dto.request.TransactionWriteRequest;
 import com.aespa.armageddon.core.domain.transaction.command.application.service.TransactionService;
-import com.aespa.armageddon.infra.security.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,48 +20,35 @@ import org.springframework.web.bind.annotation.*;
 public class TransactionController {
 
     private final TransactionService transactionService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/write")
     @Operation(summary = "Create transaction")
     public ApiResult<?> writeTransaction(
-            @Parameter(description = "Bearer access token", required = true, example = "Bearer eyJ...")
-            @RequestHeader("Authorization") String authorization,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody TransactionWriteRequest request) {
 
-        String token = authorization.substring(7);
-        Long userNo = jwtTokenProvider.getUserIdFromJWT(token);
-        transactionService.writeTransaction(userNo, request);
+        transactionService.writeTransaction(userDetails.getUserId(), request);
         return ApiResult.success();
     }
 
     @PutMapping("/edit/{transactionId}")
     @Operation(summary = "Edit transaction")
     public ApiResult<?> editTransaction(
-            @Parameter(description = "Bearer access token", required = true, example = "Bearer eyJ...")
-            @RequestHeader("Authorization") String authorization,
-            @Parameter(description = "Transaction id")
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long transactionId,
             @RequestBody TransactionEditRequest request
     ) {
-        String token = authorization.substring(7);
-        Long userNo = jwtTokenProvider.getUserIdFromJWT(token);
-        transactionService.editTransaction(userNo, transactionId, request);
+        transactionService.editTransaction(userDetails.getUserId(), transactionId, request);
         return ApiResult.success();
     }
 
     @DeleteMapping("/delete/{transactionId}")
     @Operation(summary = "Delete transaction")
     public ApiResult<?> deleteTransaction(
-            @Parameter(description = "Bearer access token", required = true, example = "Bearer eyJ...")
-            @RequestHeader("Authorization") String authorization,
-            @Parameter(description = "Transaction id")
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long transactionId
     ) {
-        String token = authorization.substring(7);
-        Long userNo = jwtTokenProvider.getUserIdFromJWT(token);
-
-        transactionService.deleteTransaction(userNo, transactionId);
+        transactionService.deleteTransaction(userDetails.getUserId(), transactionId);
         return ApiResult.success();
     }
 }

--- a/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/query/controller/TransactionQueryController.java
+++ b/backend/armageddon/src/main/java/com/aespa/armageddon/core/domain/transaction/query/controller/TransactionQueryController.java
@@ -1,10 +1,7 @@
 package com.aespa.armageddon.core.domain.transaction.query.controller;
 
-import com.aespa.armageddon.core.common.support.error.CoreException;
-import com.aespa.armageddon.core.common.support.error.ErrorType;
 import com.aespa.armageddon.core.common.support.response.ApiResult;
-import com.aespa.armageddon.core.domain.auth.entity.User;
-import com.aespa.armageddon.core.domain.auth.repository.UserRepository;
+import com.aespa.armageddon.core.domain.auth.security.CustomUserDetails;
 import com.aespa.armageddon.core.domain.transaction.query.dto.TransactionDailyResponse;
 import com.aespa.armageddon.core.domain.transaction.query.dto.TransactionLatelyResponse;
 import com.aespa.armageddon.core.domain.transaction.query.dto.TransactionResponse;
@@ -17,7 +14,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -31,74 +27,60 @@ import java.util.List;
 public class TransactionQueryController {
 
         private final TransactionQueryService transactionQueryService;
-        private final UserRepository userRepository;
 
         /* 최근 거래 내역 리스트 조회 */
         @GetMapping("/list")
         @Operation(summary = "Get top 5 recent transactions")
         public ApiResult<List<TransactionLatelyResponse>> getLatelyTransactions(
-                        @AuthenticationPrincipal UserDetails userDetails) {
+                        @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-                User user = userRepository.findByLoginId(userDetails.getUsername())
-                                .orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
-
-                return ApiResult.success(transactionQueryService.getLatelyTransactions(user.getId()));
+                return ApiResult.success(transactionQueryService.getLatelyTransactions(userDetails.getUserId()));
         }
 
         /* 일간 상세 내역 조회 (날짜 클릭 시 리스트) */
         @GetMapping("/daily")
         @Operation(summary = "Get daily transactions")
         public ApiResult<List<TransactionDailyResponse>> getDailyTransactions(
-                        @AuthenticationPrincipal UserDetails userDetails,
+                        @AuthenticationPrincipal CustomUserDetails userDetails,
                         @Parameter(description = "Date to query (YYYY-MM-DD)")
                         @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
 
-                User user = userRepository.findByLoginId(userDetails.getUsername())
-                                .orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
-
-                return ApiResult.success(transactionQueryService.getDailyTransactions(user.getId(), date));
+                return ApiResult.success(transactionQueryService.getDailyTransactions(userDetails.getUserId(), date));
         }
 
         /* 수입, 지출 입력/수정 모달창*/
         @GetMapping("/modal")
         @Operation(summary = "Get transaction detail")
         public ApiResult<List<TransactionResponse>> getTransactions(
-                        @AuthenticationPrincipal UserDetails userDetails,
+                        @AuthenticationPrincipal CustomUserDetails userDetails,
                         @Parameter(description = "Transaction ID")
                         @RequestParam Long transactionId
                         ) {
 
-                User user = userRepository.findByLoginId(userDetails.getUsername())
-                        .orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
-
-                return ApiResult.success(transactionQueryService.getTransactions(user.getId(), transactionId));
+                return ApiResult.success(transactionQueryService.getTransactions(
+                        userDetails.getUserId(), transactionId));
         }
 
         /* 일간 총 수입/지출/잔액 요약 조회 */
         @GetMapping("/daily/summary")
         @Operation(summary = "Get daily transaction summary(income, expense, balance)")
         public ApiResult<TransactionSummaryResponse> getDailySummary(
-                        @AuthenticationPrincipal UserDetails userDetails,
+                        @AuthenticationPrincipal CustomUserDetails userDetails,
                         @Parameter(description = "Date to query (YYYY-MM-DD)")
                         @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
 
-                User user = userRepository.findByLoginId(userDetails.getUsername())
-                                .orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
-
-                return ApiResult.success(transactionQueryService.getDailySummary(user.getId(), date));
+                return ApiResult.success(transactionQueryService.getDailySummary(userDetails.getUserId(), date));
         }
 
         /* 월간 요약 정보 조회 (수입, 지출, 잔액) */
         @GetMapping("/monthly")
         @Operation(summary = "Get monthly transaction summary")
         public ApiResult<TransactionSummaryResponse> getMonthlySummary(
-                        @AuthenticationPrincipal UserDetails userDetails,
+                        @AuthenticationPrincipal CustomUserDetails userDetails,
                         @Parameter(description = "Year (e.g. 2025)") @RequestParam int year,
                         @Parameter(description = "Month (1-12)") @RequestParam int month) {
 
-                User user = userRepository.findByLoginId(userDetails.getUsername())
-                                .orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
-
-                return ApiResult.success(transactionQueryService.getMonthlySummary(user.getId(), year, month));
+                return ApiResult.success(transactionQueryService.getMonthlySummary(
+                        userDetails.getUserId(), year, month));
         }
 }

--- a/backend/armageddon/src/test/java/com/aespa/armageddon/core/api/user/controller/MockUserDetailsArgumentResolver.java
+++ b/backend/armageddon/src/test/java/com/aespa/armageddon/core/api/user/controller/MockUserDetailsArgumentResolver.java
@@ -2,16 +2,13 @@ package com.aespa.armageddon.core.api.user.controller;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
+import com.aespa.armageddon.core.domain.auth.security.CustomUserDetails;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import java.security.Principal;
-import java.util.Collections;
 
 public class MockUserDetailsArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -26,10 +23,6 @@ public class MockUserDetailsArgumentResolver implements HandlerMethodArgumentRes
         Principal principal = webRequest.getUserPrincipal();
         String username = principal != null ? principal.getName() : "testuser";
 
-        return User.builder()
-                .username(username)
-                .password("password")
-                .authorities(Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")))
-                .build();
+        return new CustomUserDetails(1L, username, "password", null);
     }
 }

--- a/backend/armageddon/src/test/java/com/aespa/armageddon/core/api/user/controller/UserControllerTest.java
+++ b/backend/armageddon/src/test/java/com/aespa/armageddon/core/api/user/controller/UserControllerTest.java
@@ -16,12 +16,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.security.Principal;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/backend/armageddon/src/test/java/com/aespa/armageddon/core/domain/transaction/query/controller/TransactionQueryControllerTest.java
+++ b/backend/armageddon/src/test/java/com/aespa/armageddon/core/domain/transaction/query/controller/TransactionQueryControllerTest.java
@@ -1,15 +1,12 @@
 package com.aespa.armageddon.core.domain.transaction.query.controller;
 
-import com.aespa.armageddon.core.domain.auth.entity.User;
-import com.aespa.armageddon.core.domain.auth.repository.UserRepository;
+import com.aespa.armageddon.core.domain.auth.security.CustomUserDetails;
 import com.aespa.armageddon.core.domain.transaction.command.domain.aggregate.Category;
 import com.aespa.armageddon.core.domain.transaction.command.domain.aggregate.TransactionType;
 import com.aespa.armageddon.core.domain.transaction.query.dto.TransactionDailyResponse;
 import com.aespa.armageddon.core.domain.transaction.query.dto.TransactionLatelyResponse;
-import com.aespa.armageddon.core.domain.transaction.query.dto.TransactionResponse;
 import com.aespa.armageddon.core.domain.transaction.query.dto.TransactionSummaryResponse;
 import com.aespa.armageddon.core.domain.transaction.query.service.TransactionQueryService;
-import com.aespa.armageddon.infra.security.JwtTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,13 +22,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -43,35 +36,19 @@ class TransactionQueryControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @SuppressWarnings("deprecation")
     @MockBean
     private TransactionQueryService transactionQueryService;
 
-    @MockBean
-    private UserRepository userRepository;
-
-    @MockBean
-    private JwtTokenProvider jwtTokenProvider;
+    private Authentication authentication() {
+        CustomUserDetails userDetails = new CustomUserDetails(1L, "testUser", "password", null);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
 
     @BeforeEach
     void setUp() {
-        // 1. SecurityContext에 들어갈 UserDetails Mocking
-        org.springframework.security.core.userdetails.UserDetails mockUserDetails = mock(
-                org.springframework.security.core.userdetails.UserDetails.class);
-        given(mockUserDetails.getUsername()).willReturn("testUser");
-        given(mockUserDetails.getAuthorities()).willReturn(Collections.emptyList());
-
-        // 2. Repository가 반환할 User Entity Mocking
-        User mockUserEntity = mock(User.class);
-        given(mockUserEntity.getId()).willReturn(1L);
-
-        // Controller가 UserDetails의 username으로 Repository 조회 시 Entity 반환하도록 설정
-        given(userRepository.findByLoginId("testUser")).willReturn(Optional.of(mockUserEntity));
-
-        // 3. SecurityContext 설정
-        Authentication auth = new UsernamePasswordAuthenticationToken(mockUserDetails, null,
-                mockUserDetails.getAuthorities());
         SecurityContext context = SecurityContextHolder.createEmptyContext();
-        context.setAuthentication(auth);
+        context.setAuthentication(authentication());
         SecurityContextHolder.setContext(context);
     }
 


### PR DESCRIPTION
## 변경 사항
- 토큰 직접 파싱 -> UserDetails사용으로 전환
- 타 도메인 컨트롤러도 user 쪽에서 수정하는게 빠를 것 같아 수정했습니다!

## 작업 내용
- [ ] 기능 구현
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 디자인 요소 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)

## 체크리스트
- [ ] 중요!! : run했을 때 멈추지 않고 돌아가는가
- [ ] Push 전 pull dev 했는가
- [ ] 불필요한 코드/주석이 없는가

## 참고 사항(생략 가능)
- 이전에 직접 토큰 파싱해 오시던 부분에 문제가 없는지 점검해주세요!

